### PR TITLE
Task/async file opening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+**1.1.1**
+
+- Fixing regression on opening files + reset device action from main vscode menu
+
 **1.1.0**
 
 - Migration to Typescript

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
 		"m5stack",
 		"mpy"
 	],
-	"version": "1.1.0",
+	"version": "1.1.1",
 	"engines": {
 		"vscode": "^1.48.0"
 	},

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,12 +14,14 @@ export function activate(context: vscode.ExtensionContext) {
   const createFile = (ev: any) => portList.create(ev);
   const removeFile = (ev: any) => portList.remove(ev);
   const uploadFile = (ev: any) => portList.upload(ev);
+  const resetDevice = (ev: any) => portList.reset();
   const run = () => portList.run();
 
   context.subscriptions.push(
     vscode.commands.registerCommand('vscode-m5stack-mpyreader.selectPorts', selectPorts, context),
     vscode.commands.registerCommand('m5stack.refreshEntry', refreshTree, context),
     vscode.commands.registerCommand('extension.openSelection', openFile, context),
+    vscode.commands.registerCommand('extension.reset.device', resetDevice, context),
     vscode.commands.registerCommand('m5stack.addEntry', createFile, context),
     vscode.commands.registerCommand('m5stack.deleteEntry', removeFile, context),
     vscode.commands.registerCommand('m5stack.itemUpload', uploadFile, context),

--- a/src/providers/M5FileSystemProvider.ts
+++ b/src/providers/M5FileSystemProvider.ts
@@ -32,8 +32,8 @@ class M5FileSystemProvider implements vscode.FileSystemProvider {
     return [];
   }
 
-  writeFile(uri: vscode.Uri) {
-    this._writeFile(uri);
+  async writeFile(uri: vscode.Uri) {
+    await this._writeFile(uri);
   }
 
   async _writeFile(uri: vscode.Uri) {

--- a/src/ui/PortList.ts
+++ b/src/ui/PortList.ts
@@ -153,6 +153,24 @@ class PortList {
     await vscode.window.showTextDocument(doc, { preview: false });
   }
 
+  reset() {
+    this._reset();
+  }
+
+  async _reset() {
+    if (vscode.window.activeTextEditor) {
+      const uri = vscode.window.activeTextEditor.document.uri;
+      const args = uri.path.split('/');
+      let port = process.platform === 'win32' ? args[1] : `/dev/${args[1]}`;
+      let r = await SerialManager.exec(port, 'machine.reset()');
+      if (!r) {
+        vscode.window.showErrorMessage('Reset device failed.');
+      } else {
+        vscode.window.showInformationMessage('Device is resetting.');
+      }
+    }
+  }
+
   async create(ev: any) {
     let filename = await vscode.window.showInputBox({
       placeHolder: 'File Name',


### PR DESCRIPTION
- Missing `async` was causing files from opening before content was pulled from the device
- Missing extension action to reset device from the main menu
- Bumped version and changelog details