### PR TITLE
Task/file loader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-.vscode
 node_modules
 yarn-error.log
 build/

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,9 +9,13 @@
       "name": "Run Extension",
       "type": "extensionHost",
       "request": "launch",
-      "args": ["--extensionDevelopmentPath=${workspaceFolder}"],
-      "outFiles": ["${workspaceFolder}/dist/**/*.js"],
-      "preLaunchTask": "${defaultBuildTask}"
+      "args": [
+        "--extensionDevelopmentPath=${workspaceFolder}"
+      ],
+      "outFiles": [
+        "${workspaceFolder}/dist/**/*.js"
+      ],
+      "preLaunchTask": "npm: watch"
     },
     {
       "name": "Extension Tests",
@@ -21,7 +25,10 @@
         "--extensionDevelopmentPath=${workspaceFolder}",
         "--extensionTestsPath=${workspaceFolder}/out/test/suite/index"
       ],
-      "outFiles": ["${workspaceFolder}/out/**/*.js", "${workspaceFolder}/dist/**/*.js"],
+      "outFiles": [
+        "${workspaceFolder}/out/**/*.js",
+        "${workspaceFolder}/dist/**/*.js"
+      ],
       "preLaunchTask": "tasks: watch-tests"
     }
   ]

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,22 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "type": "npm",
+            "script": "build",
+            "isBackground": false,
+            "group": {
+                "isDefault": true,
+                "kind": "build"
+            },
+            "label": "npm: build"
+        },
+        {
+            "type": "npm",
+            "script": "watch",
+            "group": "build",
+            "isBackground": true,
+            "label": "npm: watch"
+        },
+    ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+**1.1.3**
+
+- New loader progress bar on File saving + enhancement in communication with device.
+- Exclude non supported files from being opened.
+
 **1.1.1**
 
 - Fixing regression on opening files + reset device action from main vscode menu

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,6 +5,7 @@ import portList from './ui/PortList';
 
 // Extensions code samples
 // https://github.com/microsoft/vscode-extension-samples
+// https://code.visualstudio.com/api/references/extension-guidelines
 export function activate(context: vscode.ExtensionContext) {
   console.log('Extension "vscode-m5stack-mpy" is now active!');
 

--- a/src/providers/M5FileSystemProvider.ts
+++ b/src/providers/M5FileSystemProvider.ts
@@ -56,9 +56,7 @@ class M5FileSystemProvider implements vscode.FileSystemProvider {
   async saveFile(uri: vscode.Uri, text: string) {
     try {
       this.files[uri.path] = Buffer.from(text);
-      let args = uri.path.split('/');
-      let port = process.platform === 'win32' ? args[1] : `/dev/${args[1]}`;
-      let filepath = `/${args.slice(2).join('/')}`;
+      const { port, filepath } = getSerialPortAndFileFromUri(uri);
       return await vscode.window.withProgress(
         {
           location: vscode.ProgressLocation.Notification,

--- a/src/utils/vscode.ts
+++ b/src/utils/vscode.ts
@@ -1,0 +1,12 @@
+import * as vscode from 'vscode';
+
+export const getSerialPortAndFileFromUri = (uri: vscode.Uri): { port: string; filepath: string } => {
+  const args = uri.path.split('/');
+  const port = process.platform === 'win32' ? args[1] : `/dev/${args[1]}`;
+  const filepath = `/${args.slice(2).join('/')}`;
+
+  return {
+    port,
+    filepath,
+  };
+};


### PR DESCRIPTION
This new PR addresses the following

- Saving file is not working for "large" files...really not that big...after a certain amount of bytes (about 300 if I remember it well) being sent it returns errors. So I made some tests and came up with sending data by chunk of 128 bytes at a time with also a new progress bar.
- Then I realised I tend to click twice in the treeview in general to open a file and was wondering what what happening, it was always hanging...I found this was due to some calls being made multiple time to read the file when the device is already processing something, so I have added a `busy` attribute that is released once work has been done and data have been received from the device.
- There is also a change to only accept opening certain text files, .py, .text, .json + most common images files.