### PR TITLE
Adds support for vscode 1.66/1.67

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+**1.1.5**
+
+- Adds support for vscode 1.66 and 1.67
+
 **1.1.4**
 
 - Fix mistake in progress bar where increment value is summed up and reflected as overall progress until 100% is reached.

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
 		"m5stack",
 		"mpy"
 	],
-	"version": "1.1.4",
+	"version": "1.1.5",
 	"engines": {
 		"vscode": "^1.48.0"
 	},

--- a/serialPortBindingsLoader.js
+++ b/serialPortBindingsLoader.js
@@ -57,8 +57,10 @@ August 2021 (version 1.60.2)
 September 2021 (version 1.61.2)
 October 2021 (version 1.62.3)
 November 2021 (version 1.63.2)
-
-https://code.visualstudio.com/updates/v1_48
+January 2022 (version 1.64) (NodeJS - 14.16.0)
+February 2022 (version 1.65) (NodeJS - 14.16.0)
+March 2022 (version 1.66) (NodeJS - 16.13.0)
+April 2022 (version 1.67) (NodeJS - 16.13.0)
 
 Below corresponding list of NodeJS version used in VSCode compiled version:
 - 14.16.0
@@ -68,7 +70,7 @@ Below corresponding list of NodeJS version used in VSCode compiled version:
 - 12.14.1
 */
 const copyBindings = () => {
-  const nodeJSVersions = ['12.14.1', '12.18.3', '12.4.0', '12.8.1', '14.16.0'];
+  const nodeJSVersions = ['12.14.1', '12.18.3', '12.4.0', '12.8.1', '14.16.0', '16.13.0'];
   const plaformsAndArch = [
     'darwin-x64',
     'darwin-arm',

--- a/yarn.lock
+++ b/yarn.lock
@@ -4077,9 +4077,9 @@ minimatch@3.0.4, minimatch@^3.0.4:
     brace-expansion "^1.1.7"
 
 minimist@^1.2.0, minimist@^1.2.3, minimist@^1.2.5:
-  version "1.2.5"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
-  integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
+  integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
 
 minipass-collect@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
hello @curdeveryday,

this should fix issues 

https://github.com/curdeveryday/vscode-m5stack-mpy/issues/31 
and 
https://github.com/curdeveryday/vscode-m5stack-mpy/issues/32

can you published a newer version once it has been merged.

thank you,

julien