### PR TITLE
Missing M5 button

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,3 +62,16 @@ code ./
 
 Then you hit F5 and verify that it works.
 See more on https://code.visualstudio.com/api
+
+## Install extention from compiled source
+
+Install the vs code page tool...
+```
+npm install -g vsce
+```
+
+Create and install the package...
+```
+vsce package
+code --install-extension vscode-m5stack-mpy-1.1.10.vsix 
+```

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ See more on https://code.visualstudio.com/api
 
 ## Install extention from compiled source
 
-Install the vs code page tool...
+Install the vs code extension packaging tool...
 ```
 npm install -g vsce
 ```

--- a/serialPortBindingsLoader.js
+++ b/serialPortBindingsLoader.js
@@ -70,7 +70,7 @@ Below corresponding list of NodeJS version used in VSCode compiled version:
 - 12.14.1
 */
 const copyBindings = () => {
-  const nodeJSVersions = ['12.14.1', '12.18.3', '12.4.0', '12.8.1', '14.16.0', '16.13.0', '16.13.2', '16.14.2', '16.17.1'];
+  const nodeJSVersions = ['12.14.1', '12.18.3', '12.4.0', '12.8.1', '14.16.0', '16.13.0', '16.13.2', '16.14.2', '16.17.1', '18.15.0'];
   const plaformsAndArch = [
     'darwin-x64',
     'darwin-arm',


### PR DESCRIPTION
Fixes https://github.com/curdeveryday/vscode-m5stack-mpy/issues/45 on a Mac M1